### PR TITLE
Rename crate in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rely on the excellent [openidconnect-rs](https://github.com/ramosbugs/openidconn
 ### Cargo.toml
 ```toml
 [dependencies]
-actix-web-openid = "~0.1.2"
+actix_web_openidconnect = "~0.1.2"
 ```
 ### main.rs
 ```rust  


### PR DESCRIPTION
The `Cargo.toml` code snippet in the README uses the wrong crate name. This also renames the README file to its standard name of `README.md`