### PR TITLE
Allow specification of additional claims

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,66 @@ use crate::openid::OpenID;
 use actix_web::dev::ServiceRequest;
 use actix_web::web;
 use actix_web::web::ServiceConfig;
+use oauth2::{EmptyExtraTokenFields, EndpointNotSet, StandardErrorResponse, StandardTokenResponse};
+use openidconnect::{
+    core::{
+        CoreAuthDisplay, CoreAuthPrompt, CoreErrorResponseType, CoreGenderClaim, CoreJsonWebKey,
+        CoreJweContentEncryptionAlgorithm, CoreJwsSigningAlgorithm, CoreRevocableToken,
+        CoreRevocationErrorResponse, CoreTokenIntrospectionResponse, CoreTokenType,
+    },
+    Client, IdTokenClaims, IdTokenFields,
+};
 use url::Url;
 
 mod openid;
 pub mod openid_middleware;
+pub use openidconnect::AdditionalClaims; // Necessary to access AdditionalClaims from outside of this create
+
+pub type ClaimClient<
+    C,
+    HasAuthUrl = EndpointNotSet,
+    HasDeviceAuthUrl = EndpointNotSet,
+    HasIntrospectionUrl = EndpointNotSet,
+    HasRevocationUrl = EndpointNotSet,
+    HasTokenUrl = EndpointNotSet,
+    HasUserInfoUrl = EndpointNotSet,
+> = Client<
+    C,
+    CoreAuthDisplay,
+    CoreGenderClaim,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJsonWebKey,
+    CoreAuthPrompt,
+    StandardErrorResponse<CoreErrorResponseType>,
+    ClaimTokenResponse<C>,
+    CoreTokenIntrospectionResponse,
+    CoreRevocableToken,
+    CoreRevocationErrorResponse,
+    HasAuthUrl,
+    HasDeviceAuthUrl,
+    HasIntrospectionUrl,
+    HasRevocationUrl,
+    HasTokenUrl,
+    HasUserInfoUrl,
+>;
+
+pub type ClaimIdTokenClaims<C> = IdTokenClaims<C, CoreGenderClaim>;
+
+pub type ClaimIdTokenFields<C> = IdTokenFields<
+    C,
+    EmptyExtraTokenFields,
+    CoreGenderClaim,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJwsSigningAlgorithm,
+>;
+pub type ClaimTokenResponse<C> = StandardTokenResponse<ClaimIdTokenFields<C>, CoreTokenType>;
 
 #[derive(Clone)]
-pub struct ActixWebOpenId {
-    openid_client: Arc<OpenID>,
+pub struct ActixWebOpenId<C = openidconnect::EmptyAdditionalClaims>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
+    openid_client: Arc<OpenID<C>>,
     should_auth: fn(&ServiceRequest) -> bool,
     use_pkce: bool,
     redirect_path: String,
@@ -87,8 +139,11 @@ impl ActixWebOpenIdBuilder {
         self
     }
 
-    pub async fn build_and_init(self) -> anyhow::Result<ActixWebOpenId> {
-        Ok(ActixWebOpenId {
+    pub async fn build_and_init<C>(self) -> anyhow::Result<ActixWebOpenId<C>>
+    where
+        C: AdditionalClaims + Clone + Sync,
+    {
+        Ok(ActixWebOpenId::<C> {
             openid_client: Arc::new(
                 OpenID::init(
                     self.client_id,
@@ -112,7 +167,10 @@ impl ActixWebOpenIdBuilder {
     }
 }
 
-impl ActixWebOpenId {
+impl<C> ActixWebOpenId<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     pub fn builder(
         client_id: String,
         redirect_url: String,
@@ -134,22 +192,22 @@ impl ActixWebOpenId {
         }
     }
 
-    pub fn configure_open_id(&self) -> impl Fn(&mut ServiceConfig) + use<'_> {
+    pub fn configure_open_id(&self) -> impl Fn(&mut ServiceConfig) + use<'_, C> {
         let client = self.openid_client.clone();
         move |cfg: &mut ServiceConfig| {
             cfg.service(
                 web::resource(self.redirect_path.clone())
-                    .route(web::get().to(openid_middleware::auth_endpoint)),
+                    .route(web::get().to(openid_middleware::auth_endpoint::<C>)),
             )
             .service(
                 web::resource(self.logout_path.clone())
-                    .route(web::get().to(openid_middleware::logout_endpoint)),
+                    .route(web::get().to(openid_middleware::logout_endpoint::<C>)),
             )
             .app_data(web::Data::new(client.clone()));
         }
     }
 
-    pub fn get_middleware(&self) -> openid_middleware::AuthenticateMiddlewareFactory {
+    pub fn get_middleware(&self) -> openid_middleware::AuthenticateMiddlewareFactory<C> {
         openid_middleware::AuthenticateMiddlewareFactory::new(
             self.openid_client.clone(),
             self.should_auth,

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -6,25 +6,29 @@ use oauth2::{
 };
 use openidconnect::core::{
     CoreAuthDisplay, CoreAuthPrompt, CoreAuthenticationFlow, CoreClaimName, CoreClaimType,
-    CoreClient, CoreClientAuthMethod, CoreGenderClaim, CoreGrantType, CoreIdTokenClaims,
-    CoreJsonWebKey, CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm,
-    CoreJwsSigningAlgorithm, CoreResponseMode, CoreResponseType, CoreSubjectIdentifierType,
-    CoreTokenIntrospectionResponse, CoreTokenResponse,
+    CoreClientAuthMethod, CoreGenderClaim, CoreGrantType, CoreJsonWebKey,
+    CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm, CoreJwsSigningAlgorithm,
+    CoreResponseMode, CoreResponseType, CoreSubjectIdentifierType, CoreTokenIntrospectionResponse,
 };
 use openidconnect::{reqwest, Client, IdToken};
 use openidconnect::{
-    AccessToken, AdditionalProviderMetadata, AuthorizationCode, ClaimsVerificationError, ClientId,
-    ClientSecret, CsrfToken, EmptyAdditionalClaims, EndSessionUrl, IssuerUrl, LogoutRequest, Nonce,
-    OAuth2TokenResponse, PostLogoutRedirectUrl, ProviderMetadata, RedirectUrl, RefreshToken, Scope,
-    TokenResponse, UserInfoClaims,
+    AccessToken, AdditionalClaims, AdditionalProviderMetadata, AuthorizationCode,
+    ClaimsVerificationError, ClientId, ClientSecret, CsrfToken, EndSessionUrl, IssuerUrl,
+    LogoutRequest, Nonce, OAuth2TokenResponse, PostLogoutRedirectUrl, ProviderMetadata,
+    RedirectUrl, RefreshToken, Scope, TokenResponse, UserInfoClaims,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use url::Url;
 
+use crate::{ClaimClient, ClaimIdTokenClaims, ClaimTokenResponse};
+
 #[derive(Clone)]
-pub struct OpenID {
-    client: ExtendedClient,
+pub struct OpenID<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
+    client: ExtendedClient<C>,
     provider_metadata: ExtendedProviderMetadata,
     post_logout_redirect_url: Option<String>,
     scopes: Vec<Scope>,
@@ -34,9 +38,12 @@ pub struct OpenID {
     pub(crate) use_pkce: bool,
 }
 
-pub struct OpenIDTokens {
+pub struct OpenIDTokens<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     pub access_token: AccessToken,
-    pub id_token: Option<ExtendedIdToken>,
+    pub id_token: Option<ExtendedIdToken<C>>,
     pub refresh_token: Option<RefreshToken>,
 }
 
@@ -68,15 +75,15 @@ pub(crate) type ExtendedProviderMetadata = ProviderMetadata<
     CoreSubjectIdentifierType,
 >;
 
-pub(crate) type ExtendedClient = Client<
-    EmptyAdditionalClaims,
+pub(crate) type ExtendedClient<C> = Client<
+    C,
     CoreAuthDisplay,
     CoreGenderClaim,
     CoreJweContentEncryptionAlgorithm,
     CoreJsonWebKey,
     CoreAuthPrompt,
     StandardErrorResponse<BasicErrorResponseType>,
-    CoreTokenResponse,
+    ClaimTokenResponse<C>,
     CoreTokenIntrospectionResponse,
     StandardRevocableToken,
     BasicRevocationErrorResponse,
@@ -88,18 +95,17 @@ pub(crate) type ExtendedClient = Client<
     EndpointMaybeSet,
 >;
 
-pub(crate) type ExtendedIdToken = IdToken<
-    EmptyAdditionalClaims,
-    CoreGenderClaim,
-    CoreJweContentEncryptionAlgorithm,
-    CoreJwsSigningAlgorithm,
->;
+pub(crate) type ExtendedIdToken<C> =
+    IdToken<C, CoreGenderClaim, CoreJweContentEncryptionAlgorithm, CoreJwsSigningAlgorithm>;
 
 fn get_http_client() -> reqwest::Client {
     reqwest::Client::builder().build().unwrap()
 }
 
-impl OpenID {
+impl<C> OpenID<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn init(
         client_id: String,
@@ -120,7 +126,7 @@ impl OpenID {
         .await
         .expect("Failed to discover OpenID Provider");
 
-        let client = CoreClient::from_provider_metadata(
+        let client = ClaimClient::from_provider_metadata(
             provider_metadata.clone(),
             ClientId::new(client_id.to_string()),
             client_secret.map(|client_secret| ClientSecret::new(client_secret.to_string())),
@@ -173,7 +179,7 @@ impl OpenID {
         &self,
         authorization_code: AuthorizationCode,
         pkce_verifier: Option<String>,
-    ) -> Result<OpenIDTokens> {
+    ) -> Result<OpenIDTokens<C>> {
         let token_response = if let Some(pkce_verifier) = pkce_verifier {
             self.client
                 .exchange_code(authorization_code)?
@@ -196,7 +202,7 @@ impl OpenID {
     pub(crate) async fn user_info(
         &self,
         access_token: AccessToken,
-    ) -> Result<UserInfoClaims<EmptyAdditionalClaims, CoreGenderClaim>> {
+    ) -> Result<UserInfoClaims<C, CoreGenderClaim>> {
         Ok(self
             .client
             .user_info(access_token, None)?
@@ -206,9 +212,9 @@ impl OpenID {
 
     pub(crate) async fn verify_id_token<'a>(
         &self,
-        id_token: &'a ExtendedIdToken,
+        id_token: &'a ExtendedIdToken<C>,
         nonce: String,
-    ) -> Result<&'a CoreIdTokenClaims, ClaimsVerificationError> {
+    ) -> Result<&'a ClaimIdTokenClaims<C>, ClaimsVerificationError> {
         id_token.claims(
             &self
                 .client
@@ -220,7 +226,7 @@ impl OpenID {
         )
     }
 
-    pub(crate) fn get_logout_uri(&self, id_token: &ExtendedIdToken) -> Url {
+    pub(crate) fn get_logout_uri(&self, id_token: &ExtendedIdToken<C>) -> Url {
         let mut logout_request = LogoutRequest::from(
             self.provider_metadata
                 .additional_metadata()

--- a/src/openid_middleware.rs
+++ b/src/openid_middleware.rs
@@ -16,7 +16,9 @@ use actix_web::http::StatusCode;
 use actix_web::{error, web, Error, FromRequest, HttpMessage, HttpRequest, HttpResponse};
 use futures_util::future::LocalBoxFuture;
 use openidconnect::core::CoreGenderClaim;
-use openidconnect::{AccessToken, AuthorizationCode, EmptyAdditionalClaims, UserInfoClaims};
+use openidconnect::{
+    AccessToken, AdditionalClaims, AuthorizationCode, EmptyAdditionalClaims, UserInfoClaims,
+};
 use serde::Deserialize;
 
 use crate::openid::{ExtendedIdToken, OpenID};
@@ -56,8 +58,11 @@ impl Display for AuthCookies {
 }
 
 #[derive(Clone)]
-pub struct AuthenticatedUser {
-    pub access: UserInfoClaims<EmptyAdditionalClaims, CoreGenderClaim>,
+pub struct AuthenticatedUser<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
+    pub access: UserInfoClaims<C, CoreGenderClaim>,
 }
 
 #[derive(Debug, derive_more::Error)]
@@ -112,18 +117,22 @@ impl error::ResponseError for AuthError {
     }
 }
 
-pub struct OpenIdMiddleware<S> {
-    openid_client: Arc<OpenID>,
+pub struct OpenIdMiddleware<C, S>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
+    openid_client: Arc<OpenID<C>>,
     service: Rc<S>,
     should_auth: fn(&ServiceRequest) -> bool,
     use_pkce: bool,
     redirect_path: String,
 }
 
-impl<S> OpenIdMiddleware<S> {}
+impl<C, S> OpenIdMiddleware<C, S> where C: AdditionalClaims + Clone + Sync {}
 
-impl<S, B> Service<ServiceRequest> for OpenIdMiddleware<S>
+impl<C, S, B> Service<ServiceRequest> for OpenIdMiddleware<C, S>
 where
+    C: AdditionalClaims + Clone + Sync,
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
 {
     type Response = ServiceResponse<B>;
@@ -177,16 +186,22 @@ where
     }
 }
 
-pub struct AuthenticateMiddlewareFactory {
-    client: Arc<OpenID>,
+pub struct AuthenticateMiddlewareFactory<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
+    client: Arc<OpenID<C>>,
     should_auth: fn(&ServiceRequest) -> bool,
     use_pkce: bool,
     redirect_path: String,
 }
 
-impl AuthenticateMiddlewareFactory {
+impl<C> AuthenticateMiddlewareFactory<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     pub(crate) fn new(
-        client: Arc<OpenID>,
+        client: Arc<OpenID<C>>,
         should_auth: fn(&ServiceRequest) -> bool,
         use_pkce: bool,
         redirect_path: String,
@@ -200,13 +215,14 @@ impl AuthenticateMiddlewareFactory {
     }
 }
 
-impl<S, B> Transform<S, ServiceRequest> for AuthenticateMiddlewareFactory
+impl<C, S, B> Transform<S, ServiceRequest> for AuthenticateMiddlewareFactory<C>
 where
+    C: AdditionalClaims + Clone + Sync,
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
-    type Transform = OpenIdMiddleware<S>;
+    type Transform = OpenIdMiddleware<C, S>;
     type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
@@ -227,10 +243,13 @@ pub(crate) struct AuthQuery {
     state: String,
 }
 
-pub(crate) async fn logout_endpoint(
+pub(crate) async fn logout_endpoint<C>(
     req: HttpRequest,
-    open_id_client: web::Data<Arc<OpenID>>,
-) -> actix_web::Result<HttpResponse> {
+    open_id_client: web::Data<Arc<OpenID<C>>>,
+) -> actix_web::Result<HttpResponse>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     let id_token = match req.cookie(AuthCookies::IdToken.to_string().as_str()) {
         None => {
             log::debug!("No id token, redirecting to auth");
@@ -244,11 +263,14 @@ pub(crate) async fn logout_endpoint(
     Ok(response.finish())
 }
 
-async fn execute_auth_endpoint(
+async fn execute_auth_endpoint<C>(
     req: &HttpRequest,
-    open_id_client: &Arc<OpenID>,
+    open_id_client: &Arc<OpenID<C>>,
     query: &AuthQuery,
-) -> actix_web::Result<HttpResponse> {
+) -> actix_web::Result<HttpResponse>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     let nonce = req
         .cookie(AuthCookies::Nonce.to_string().as_str())
         .ok_or_else(|| {
@@ -344,11 +366,14 @@ async fn execute_auth_endpoint(
     })
 }
 
-pub(crate) async fn auth_endpoint(
+pub(crate) async fn auth_endpoint<C>(
     req: HttpRequest,
-    open_id_client: web::Data<Arc<OpenID>>,
+    open_id_client: web::Data<Arc<OpenID<C>>>,
     query: web::Query<AuthQuery>,
-) -> actix_web::Result<HttpResponse> {
+) -> actix_web::Result<HttpResponse>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     let res = execute_auth_endpoint(&req, &open_id_client, &query).await;
     if res.is_err() && open_id_client.redirect_on_error {
         let url = open_id_client.get_authorization_url("/".to_string(), open_id_client.use_pkce);
@@ -360,22 +385,30 @@ pub(crate) async fn auth_endpoint(
     }
 }
 
-pub struct Authenticated(AuthenticatedUser);
+pub struct Authenticated<C = EmptyAdditionalClaims>(AuthenticatedUser<C>)
+where
+    C: AdditionalClaims + Clone + Sync;
 
-impl FromRequest for Authenticated {
+impl<C> FromRequest for Authenticated<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
     type Error = Error;
     type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut actix_web::dev::Payload) -> Self::Future {
-        let value = req.extensions().get::<AuthenticatedUser>().cloned();
+        let value = req.extensions().get::<AuthenticatedUser<C>>().cloned();
         let result = value.ok_or(ErrorUnauthorized("Unauthorized")).map(Self);
 
         ready(result)
     }
 }
 
-impl std::ops::Deref for Authenticated {
-    type Target = AuthenticatedUser;
+impl<C> std::ops::Deref for Authenticated<C>
+where
+    C: AdditionalClaims + Clone + Sync,
+{
+    type Target = AuthenticatedUser<C>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -82,7 +82,7 @@ async fn test_add() {
     let should_auth =
         |req: &actix_web::dev::ServiceRequest| !req.path().starts_with("/no_auth/hello");
 
-    let open_id_actix_web = ActixWebOpenId::builder(
+    let open_id_actix_web = ActixWebOpenId::<openidconnect::EmptyAdditionalClaims>::builder(
         "test_client_id".to_string(),
         "http://redirect_url.com/authpath".to_string(),
         issuer_url,


### PR DESCRIPTION
This PR adds a ClaimClient which allows you to accept additional OIDC claims.
So you can use 
```rust
#[derive(Clone, Debug, Deserialize, Serialize)]
pub struct GroupClaims {
	groups: Vec<String>,
}
impl actix_web_openidconnect::AdditionalClaims for GroupClaims {}

let openid: ActixWebOpenId<GroupClaims> = ActixWebOpenId::<GroupClaims>::builder(...)
```

to access the `groups` claim.

I am unsure how well I implemented this whole stuff, but it works. I especially don’t like having to specify `GroupClaims` twice.
A problem I see is that you could write
```rust
let openid: ActixWebOpenId = ActixWebOpenId::<GroupClaims>::builder(...)
```
which would lead to a `ActixWebOpenId<EmptyAdditionalClaims>` instead.
On the other hand the [default](https://github.com/Cameo007/ActixWeb_openIDConnect/blob/master/src/lib.rs#L70) allows users to not specify `C` in case they don’t need additional claims, which is think is important to keep.

Thank you for this project btw!