### PR TITLE
Add on_login method to specify a closure which is called with the received claims when logging in

### DIFF
--- a/readMe.md
+++ b/readMe.md
@@ -83,6 +83,19 @@ let openid: ActixWebOpenId<GroupClaims> = ActixWebOpenId::<GroupClaims>::builder
 
 </details>
 
+<details>
+
+<summary>Call a function with the received claims on login</summary>
+
+```rust
+let openid: ActixWebOpenId<GroupClaims> = ActixWebOpenId::<GroupClaims>::builder(...)
+    .on_login(|claims| {
+        println!("{} logged in!", claims.preferred_username().unwrap().as_str())
+    })
+```
+
+</details>
+
 # Parameters
 
 | name                     | description                                                                                                                                                                                               | Example                                                                                                                        | doc                                                                                                                  |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! Documentation: https://github.com/RomainMichau/ActixWeb_openIDConnect
 //!
 
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 use crate::openid::OpenID;
 use actix_web::dev::ServiceRequest;
@@ -67,18 +67,23 @@ pub type ClaimIdTokenFields<C> = IdTokenFields<
 pub type ClaimTokenResponse<C> = StandardTokenResponse<ClaimIdTokenFields<C>, CoreTokenType>;
 
 #[derive(Clone)]
-pub struct ActixWebOpenId<C = openidconnect::EmptyAdditionalClaims>
+pub struct ActixWebOpenId<C = openidconnect::EmptyAdditionalClaims, F = fn(&ClaimIdTokenClaims<C>)>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Sync,
 {
-    openid_client: Arc<OpenID<C>>,
+    openid_client: Arc<OpenID<C, F>>,
     should_auth: fn(&ServiceRequest) -> bool,
     use_pkce: bool,
     redirect_path: String,
     logout_path: String,
 }
 
-pub struct ActixWebOpenIdBuilder {
+pub struct ActixWebOpenIdBuilder<C, F>
+where
+    C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>),
+{
     client_id: String,
     client_secret: Option<String>,
     redirect_url: Url,
@@ -91,9 +96,15 @@ pub struct ActixWebOpenIdBuilder {
     use_pkce: bool,
     redirect_on_error: bool,
     allow_all_audiences: bool,
+    on_login: F,
+    phantom: PhantomData<C>,
 }
 
-impl ActixWebOpenIdBuilder {
+impl<C, F> ActixWebOpenIdBuilder<C, F>
+where
+    C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Sync,
+{
     pub fn client_secret(mut self, secret: impl Into<String>) -> Self {
         self.client_secret = Some(secret.into());
         self
@@ -102,6 +113,28 @@ impl ActixWebOpenIdBuilder {
     pub fn should_auth(mut self, f: fn(&ServiceRequest) -> bool) -> Self {
         self.should_auth = f;
         self
+    }
+
+    pub fn on_login<G>(self, f: G) -> ActixWebOpenIdBuilder<C, G>
+    where
+        G: Fn(&ClaimIdTokenClaims<C>) + Sync + 'static,
+    {
+        ActixWebOpenIdBuilder {
+            on_login: f,
+            client_id: self.client_id,
+            client_secret: self.client_secret,
+            redirect_url: self.redirect_url,
+            logout_path: self.logout_path,
+            issuer_url: self.issuer_url,
+            should_auth: self.should_auth,
+            post_logout_redirect_url: self.post_logout_redirect_url,
+            scopes: self.scopes,
+            additional_audiences: self.additional_audiences,
+            use_pkce: self.use_pkce,
+            redirect_on_error: self.redirect_on_error,
+            allow_all_audiences: self.allow_all_audiences,
+            phantom: PhantomData,
+        }
     }
 
     pub fn post_logout_redirect_url(mut self, url: impl Into<String>) -> Self {
@@ -139,11 +172,8 @@ impl ActixWebOpenIdBuilder {
         self
     }
 
-    pub async fn build_and_init<C>(self) -> anyhow::Result<ActixWebOpenId<C>>
-    where
-        C: AdditionalClaims + Clone + Sync,
-    {
-        Ok(ActixWebOpenId::<C> {
+    pub async fn build_and_init(self) -> anyhow::Result<ActixWebOpenId<C, F>> {
+        Ok(ActixWebOpenId::<C, F> {
             openid_client: Arc::new(
                 OpenID::init(
                     self.client_id,
@@ -156,6 +186,7 @@ impl ActixWebOpenIdBuilder {
                     self.allow_all_audiences,
                     self.use_pkce,
                     self.redirect_on_error,
+                    self.on_login,
                 )
                 .await?,
             ),
@@ -167,7 +198,7 @@ impl ActixWebOpenIdBuilder {
     }
 }
 
-impl<C> ActixWebOpenId<C>
+impl<C> ActixWebOpenId<C, fn(&ClaimIdTokenClaims<C>)>
 where
     C: AdditionalClaims + Clone + Sync,
 {
@@ -175,7 +206,7 @@ where
         client_id: String,
         redirect_url: String,
         issuer_url: String,
-    ) -> ActixWebOpenIdBuilder {
+    ) -> ActixWebOpenIdBuilder<C, fn(&ClaimIdTokenClaims<C>)> {
         ActixWebOpenIdBuilder {
             client_id,
             client_secret: None,
@@ -189,25 +220,33 @@ where
             use_pkce: false,
             redirect_on_error: false,
             allow_all_audiences: false,
+            on_login: |_| {},
+            phantom: PhantomData,
         }
     }
+}
 
-    pub fn configure_open_id(&self) -> impl Fn(&mut ServiceConfig) + use<'_, C> {
+impl<C, F> ActixWebOpenId<C, F>
+where
+    C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Sync + 'static,
+{
+    pub fn configure_open_id(&self) -> impl Fn(&mut ServiceConfig) + use<'_, C, F> {
         let client = self.openid_client.clone();
         move |cfg: &mut ServiceConfig| {
             cfg.service(
                 web::resource(self.redirect_path.clone())
-                    .route(web::get().to(openid_middleware::auth_endpoint::<C>)),
+                    .route(web::get().to(openid_middleware::auth_endpoint::<C, F>)),
             )
             .service(
                 web::resource(self.logout_path.clone())
-                    .route(web::get().to(openid_middleware::logout_endpoint::<C>)),
+                    .route(web::get().to(openid_middleware::logout_endpoint::<C, F>)),
             )
             .app_data(web::Data::new(client.clone()));
         }
     }
 
-    pub fn get_middleware(&self) -> openid_middleware::AuthenticateMiddlewareFactory<C> {
+    pub fn get_middleware(&self) -> openid_middleware::AuthenticateMiddlewareFactory<C, F> {
         openid_middleware::AuthenticateMiddlewareFactory::new(
             self.openid_client.clone(),
             self.should_auth,

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -24,9 +24,10 @@ use url::Url;
 use crate::{ClaimClient, ClaimIdTokenClaims, ClaimTokenResponse};
 
 #[derive(Clone)]
-pub struct OpenID<C>
+pub struct OpenID<C, F>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>),
 {
     client: ExtendedClient<C>,
     provider_metadata: ExtendedProviderMetadata,
@@ -36,6 +37,7 @@ where
     pub(crate) redirect_on_error: bool,
     allow_all_audiences: bool,
     pub(crate) use_pkce: bool,
+    pub(crate) on_login: F,
 }
 
 pub struct OpenIDTokens<C>
@@ -102,9 +104,10 @@ fn get_http_client() -> reqwest::Client {
     reqwest::Client::builder().build().unwrap()
 }
 
-impl<C> OpenID<C>
+impl<C, F> OpenID<C, F>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Sync,
 {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn init(
@@ -118,6 +121,7 @@ where
         allow_all_audiences: bool,
         use_pkce: bool,
         redirect_on_error: bool,
+        on_login: F,
     ) -> Result<Self> {
         let provider_metadata = ExtendedProviderMetadata::discover_async(
             IssuerUrl::new(issuer_url)?,
@@ -144,6 +148,7 @@ where
             use_pkce,
             redirect_on_error,
             allow_all_audiences,
+            on_login,
         })
     }
 

--- a/src/openid_middleware.rs
+++ b/src/openid_middleware.rs
@@ -22,6 +22,7 @@ use openidconnect::{
 use serde::Deserialize;
 
 use crate::openid::{ExtendedIdToken, OpenID};
+use crate::ClaimIdTokenClaims;
 
 enum AuthCookies {
     AccessToken,
@@ -117,23 +118,30 @@ impl error::ResponseError for AuthError {
     }
 }
 
-pub struct OpenIdMiddleware<C, S>
+pub struct OpenIdMiddleware<C, S, F>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Clone + Sync,
 {
-    openid_client: Arc<OpenID<C>>,
+    openid_client: Arc<OpenID<C, F>>,
     service: Rc<S>,
     should_auth: fn(&ServiceRequest) -> bool,
     use_pkce: bool,
     redirect_path: String,
 }
 
-impl<C, S> OpenIdMiddleware<C, S> where C: AdditionalClaims + Clone + Sync {}
+impl<C, S, F> OpenIdMiddleware<C, S, F>
+where
+    C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Clone + Sync,
+{
+}
 
-impl<C, S, B> Service<ServiceRequest> for OpenIdMiddleware<C, S>
+impl<C, S, B, F> Service<ServiceRequest> for OpenIdMiddleware<C, S, F>
 where
     C: AdditionalClaims + Clone + Sync,
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    F: Fn(&ClaimIdTokenClaims<C>) + Clone + Sync + 'static,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
@@ -186,22 +194,24 @@ where
     }
 }
 
-pub struct AuthenticateMiddlewareFactory<C>
+pub struct AuthenticateMiddlewareFactory<C, F>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>),
 {
-    client: Arc<OpenID<C>>,
+    client: Arc<OpenID<C, F>>,
     should_auth: fn(&ServiceRequest) -> bool,
     use_pkce: bool,
     redirect_path: String,
 }
 
-impl<C> AuthenticateMiddlewareFactory<C>
+impl<C, F> AuthenticateMiddlewareFactory<C, F>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>),
 {
     pub(crate) fn new(
-        client: Arc<OpenID<C>>,
+        client: Arc<OpenID<C, F>>,
         should_auth: fn(&ServiceRequest) -> bool,
         use_pkce: bool,
         redirect_path: String,
@@ -215,14 +225,15 @@ where
     }
 }
 
-impl<C, S, B> Transform<S, ServiceRequest> for AuthenticateMiddlewareFactory<C>
+impl<C, S, B, F> Transform<S, ServiceRequest> for AuthenticateMiddlewareFactory<C, F>
 where
     C: AdditionalClaims + Clone + Sync,
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    F: Fn(&ClaimIdTokenClaims<C>) + Clone + Sync + 'static,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
-    type Transform = OpenIdMiddleware<C, S>;
+    type Transform = OpenIdMiddleware<C, S, F>;
     type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
@@ -243,12 +254,13 @@ pub(crate) struct AuthQuery {
     state: String,
 }
 
-pub(crate) async fn logout_endpoint<C>(
+pub(crate) async fn logout_endpoint<C, F>(
     req: HttpRequest,
-    open_id_client: web::Data<Arc<OpenID<C>>>,
+    open_id_client: web::Data<Arc<OpenID<C, F>>>,
 ) -> actix_web::Result<HttpResponse>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Sync,
 {
     let id_token = match req.cookie(AuthCookies::IdToken.to_string().as_str()) {
         None => {
@@ -263,13 +275,14 @@ where
     Ok(response.finish())
 }
 
-async fn execute_auth_endpoint<C>(
+async fn execute_auth_endpoint<C, F>(
     req: &HttpRequest,
-    open_id_client: &Arc<OpenID<C>>,
+    open_id_client: &Arc<OpenID<C, F>>,
     query: &AuthQuery,
 ) -> actix_web::Result<HttpResponse>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Sync,
 {
     let nonce = req
         .cookie(AuthCookies::Nonce.to_string().as_str())
@@ -342,6 +355,7 @@ where
     }
 
     if let Some(claims) = claims {
+        (open_id_client.on_login)(claims);
         response.cookie(
             Cookie::build::<String, String>(
                 AuthCookies::UserInfo.to_string(),
@@ -366,13 +380,14 @@ where
     })
 }
 
-pub(crate) async fn auth_endpoint<C>(
+pub(crate) async fn auth_endpoint<C, F>(
     req: HttpRequest,
-    open_id_client: web::Data<Arc<OpenID<C>>>,
+    open_id_client: web::Data<Arc<OpenID<C, F>>>,
     query: web::Query<AuthQuery>,
 ) -> actix_web::Result<HttpResponse>
 where
     C: AdditionalClaims + Clone + Sync,
+    F: Fn(&ClaimIdTokenClaims<C>) + Sync,
 {
     let res = execute_auth_endpoint(&req, &open_id_client, &query).await;
     if res.is_err() && open_id_client.redirect_on_error {


### PR DESCRIPTION
I needed to create users in the database as soon as they logged in and so I added this `on_login` method, taking a closure which is then executed when a user logs in. Inside this closure one can use the received claims.